### PR TITLE
Add escape sequence parsing for args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = '2018'
 name = "csv-groupby"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Steve Flanagan"]
 
 description="execute a sql-like group-by on arbitrary text or csv files"
@@ -76,6 +76,7 @@ itertools = "0.8.0"
 fxhash = "0.2.1"
 fnv = "1.0.6"
 seahash = "3.0.6"
+unescape = "0.1.0"
 
 
 assert_cmd = "0.10"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,7 +99,7 @@ pub struct CliCfg {
 
     #[structopt(short = "d", long = "input_delimiter", name = "delimiter", default_value = ",")]
     /// Delimiter if in csv mode
-    pub delimiter: char,
+    pub delimiter: String,
 
     #[structopt(short = "o", long = "output_delimiter", name = "outputdelimiter", default_value = ",")]
     /// Output delimiter for written summaries
@@ -213,6 +213,13 @@ pub fn get_cli() -> Result<Arc<CliCfg>> {
         fn re_map(v: usize) -> Result<usize> {
             if v == 0 { return Err("Field indices must start at base 1")?; }
             Ok(v-1)
+        }
+
+        if cfg.delimiter.len() > 1 {
+            cfg.delimiter = unescape::unescape(&cfg.delimiter).unwrap();
+            if cfg.delimiter.len() > 1 {
+                return Err("--input_delimiter is too long: must have length 1")?;
+            }
         }
 
         add_n_check(&mut cfg.key_fields, "-k")?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -100,11 +100,9 @@ pub struct CliCfg {
     #[structopt(short = "d", long = "input_delimiter", name = "delimiter", default_value = ",")]
     /// Delimiter if in csv mode
     pub delimiter: String,
-
     #[structopt(short = "o", long = "output_delimiter", name = "outputdelimiter", default_value = ",")]
     /// Output delimiter for written summaries
     pub od: String,
-
     #[structopt(short = "c", long = "csv_output")]
     /// Write delimited output summary instead of auto-aligned table output
     pub csv_output: bool,
@@ -112,7 +110,6 @@ pub struct CliCfg {
     #[structopt(short = "v", parse(from_occurrences))]
     /// Verbosity - use more than one v for greater detail
     pub verbose: usize,
-
     #[structopt(long = "skip_header")]
     /// Skip the first (header) line of input for each file or all of stdin
     pub skip_header: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -100,9 +100,11 @@ pub struct CliCfg {
     #[structopt(short = "d", long = "input_delimiter", name = "delimiter", default_value = ",")]
     /// Delimiter if in csv mode
     pub delimiter: char,
+
     #[structopt(short = "o", long = "output_delimiter", name = "outputdelimiter", default_value = ",")]
     /// Output delimiter for written summaries
     pub od: String,
+
     #[structopt(short = "c", long = "csv_output")]
     /// Write delimited output summary instead of auto-aligned table output
     pub csv_output: bool,
@@ -110,6 +112,7 @@ pub struct CliCfg {
     #[structopt(short = "v", parse(from_occurrences))]
     /// Verbosity - use more than one v for greater detail
     pub verbose: usize,
+
     #[structopt(long = "skip_header")]
     /// Skip the first (header) line of input for each file or all of stdin
     pub skip_header: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -704,7 +704,7 @@ fn _worker_csv(
 
     let mut builder = csv::ReaderBuilder::new();
     //let delimiter = dbg!(cfg.delimiter.expect("delimiter is malformed"));
-    builder.delimiter(cfg.delimiter as u8).has_headers(cfg.skip_header).flexible(true);//.escape(Some(b'\\')).flexible(true).comment(Some(b'#'));
+    builder.delimiter(cfg.delimiter.chars().next().unwrap() as u8).has_headers(cfg.skip_header).flexible(true);//.escape(Some(b'\\')).flexible(true).comment(Some(b'#'));
 
     let mut buff = String::with_capacity(256); // dyn buffer
     let mut fieldcount = 0;

--- a/src/test.rs
+++ b/src/test.rs
@@ -20,16 +20,17 @@ mod tests {
     lazy_static! {
         static ref INPUT_SET_1_WITH_FINAL_NEWLINE: String = create_fake_input1(true);
         static ref INPUT_SET_1_NO_FINAL_NEWLINE: String = create_fake_input1(false);
+        static ref INPUT_SET_1_TAB_DELIMITED: String = create_fake_input_base(false, "\t".to_string());
     }
     use super::*;
 
-    fn create_fake_input1(final_newline: bool) -> String {
+    fn create_fake_input_base(final_newline: bool, delimiter: String) -> String {
         let mut input_str = String::new();
         for i in 1..1000 {
             let q = i % 10;
             let j = i * 10;
             let k = i as f64 * 2.0f64;
-            input_str.push_str(&format!("{},{},{},{}", q, i, j, k));
+            input_str.push_str(&format!("{}{d}{}{d}{}{d}{}", q, i, j, k, d = delimiter));
             if i < 999 {
                 input_str.push_str("\n");
             }
@@ -39,6 +40,10 @@ mod tests {
             input_str.push_str("\n");
         }
         input_str
+    }
+
+    fn create_fake_input1(final_newline: bool) -> String {
+        return create_fake_input_base(final_newline, ",".to_string());
     }
 
     static EXPECTED_OUT1: &str = "k:1,count,s:4,a:1,u:2
@@ -188,5 +193,10 @@ mod tests {
             "",
             EXPECTED_OUT2,
         )
+    }
+
+    #[test]
+    fn alternative_escaped_delimiter() -> Result<(), Box<dyn std::error::Error>> {
+        stdin_test_driver("-d \\t -k 1 -s 4 -u 2 -a 1 -c -n 1", &INPUT_SET_1_TAB_DELIMITED, EXPECTED_OUT1)
     }
 }


### PR DESCRIPTION
Resolves #1 

... somewhat.

It really only adds escape sequence parsing for the `--input_delimiter` argument, but could relatively easily be extended across the other string arguments.